### PR TITLE
Remove minLength from reset password form field

### DIFF
--- a/src/app/(frontend)/reset-password/page.tsx
+++ b/src/app/(frontend)/reset-password/page.tsx
@@ -156,7 +156,6 @@ function ResetPasswordForm() {
                   value={formData.password}
                   onChange={handleInputChange}
                   placeholder="••••••••"
-                  minLength={8}
                 />
               </div>
 
@@ -172,7 +171,6 @@ function ResetPasswordForm() {
                   value={formData.confirmPassword}
                   onChange={handleInputChange}
                   placeholder="••••••••"
-                  minLength={8}
                 />
               </div>
 


### PR DESCRIPTION
Unnecessary validation since there's already a client-side check when clicking submit.